### PR TITLE
Support Solidity 0.7.x/0.8.x

### DIFF
--- a/contracts/BokkyPooBahsDateTimeContract.sol
+++ b/contracts/BokkyPooBahsDateTimeContract.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0 <0.9.0;
 
 // ----------------------------------------------------------------------------
 // BokkyPooBah's DateTime Library v1.00 - Contract Instance

--- a/contracts/BokkyPooBahsDateTimeLibrary.sol
+++ b/contracts/BokkyPooBahsDateTimeLibrary.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0 <0.9.0;
 
 // ----------------------------------------------------------------------------
 // BokkyPooBah's DateTime Library v1.01

--- a/contracts/TestDateTime.sol
+++ b/contracts/TestDateTime.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0 <0.9.0;
 
 import "BokkyPooBahsDateTimeLibrary.sol";
 


### PR DESCRIPTION
For 0.8.x one could use unchecked blocks to save gas, nevertheless this works.

To be fair haven't tested every function, only `timestampToDate`.