### PR TITLE
fix: contract imports and license clarification

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,7 @@
 SPDX-License-Identifier: LGPL-3.0-or-later
 SPDX-FileCopyrightText: Copyright (c) 2018 The Officious BokkyPooBah / Bok Consulting Pty Ltd
 
+
                    GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 The Officious BokkyPooBah / Bok Consulting Pty Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/contracts/BokkyPooBahsDateTimeContract.sol
+++ b/contracts/BokkyPooBahsDateTimeContract.sol
@@ -1,8 +1,8 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: LGPL-3.0-or-later
 pragma solidity >=0.6.0 <0.9.0;
 
 // ----------------------------------------------------------------------------
-// BokkyPooBah's DateTime Library v1.00 - Contract Instance
+// BokkyPooBah's DateTime Library v1.0.1 - Contract Instance
 //
 // A gas-efficient Solidity date and time library
 //

--- a/contracts/BokkyPooBahsDateTimeContract.sol
+++ b/contracts/BokkyPooBahsDateTimeContract.sol
@@ -29,7 +29,7 @@ pragma solidity >=0.6.0 <0.9.0;
 // https://www.gnu.org/licenses/lgpl-3.0.en.html
 // ----------------------------------------------------------------------------
 
-import "BokkyPooBahsDateTimeLibrary.sol";
+import "./BokkyPooBahsDateTimeLibrary.sol";
 
 contract BokkyPooBahsDateTimeContract {
     uint public constant SECONDS_PER_DAY = 24 * 60 * 60;

--- a/contracts/BokkyPooBahsDateTimeLibrary.sol
+++ b/contracts/BokkyPooBahsDateTimeLibrary.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.6.0 <0.9.0;
 
 // ----------------------------------------------------------------------------
-// BokkyPooBah's DateTime Library v1.01
+// BokkyPooBah's DateTime Library v1.0.1
 //
 // A gas-efficient Solidity date and time library
 //

--- a/contracts/BokkyPooBahsDateTimeLibrary.sol
+++ b/contracts/BokkyPooBahsDateTimeLibrary.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: MIT
 pragma solidity >=0.6.0 <0.9.0;
 
 // ----------------------------------------------------------------------------

--- a/contracts/TestDateTime.sol
+++ b/contracts/TestDateTime.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.6.0 <0.9.0;
 
-import "BokkyPooBahsDateTimeLibrary.sol";
+import "./BokkyPooBahsDateTimeLibrary.sol";
 
 // ----------------------------------------------------------------------------
 // Testing BokkyPooBah's DateTime Library

--- a/contracts/TestDateTime.sol
+++ b/contracts/TestDateTime.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+/// SPDX-License-Identifier: MIT
 pragma solidity >=0.6.0 <0.9.0;
 
 import "./BokkyPooBahsDateTimeLibrary.sol";

--- a/test/BokkyPooBahsDateTimeLibrary.sol
+++ b/test/BokkyPooBahsDateTimeLibrary.sol
@@ -1,7 +1,8 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0 <0.9.0;
 
 // ----------------------------------------------------------------------------
-// BokkyPooBah's DateTime Library v1.01
+// BokkyPooBah's DateTime Library v1.0.1
 //
 // A gas-efficient Solidity date and time library
 //
@@ -43,7 +44,7 @@ library BokkyPooBahsDateTimeLibrary {
     // ------------------------------------------------------------------------
     // Calculate the number of days from 1970/01/01 to year/month/day using
     // the date conversion algorithm from
-    //   http://aa.usno.navy.mil/faq/docs/JD_Formula.php
+    //   https://aa.usno.navy.mil/faq/JD_formula.html
     // and subtracting the offset 2440588 so that 1970/01/01 is day 0
     //
     // days = day

--- a/test/TestDateTime.sol
+++ b/test/TestDateTime.sol
@@ -1,6 +1,7 @@
-pragma solidity ^0.6.0;
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0 <0.9.0;
 
-import "BokkyPooBahsDateTimeLibrary.sol";
+import "../contracts/BokkyPooBahsDateTimeLibrary.sol";
 
 // ----------------------------------------------------------------------------
 // Testing BokkyPooBah's DateTime Library


### PR DESCRIPTION
updated contracts to use "./import" (forge won't import from "filename")

updated repo license to reflect LGPL-3.0 license for the library